### PR TITLE
Feature/site editor support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `contentSchemas.json` file to support different prop values for different locales.
 
 ## [0.2.0] - 2021-07-27
 

--- a/manifest.json
+++ b/manifest.json
@@ -4,11 +4,12 @@
   "version": "0.2.0",
   "title": "Product Availability",
   "description": "Show different messages depending on your product available quantity",
-  "defaultLocale": "pt-BR",
+  "defaultLocale": "en-US",
   "builders": {
     "store": "0.x",
     "react": "3.x",
-    "docs": "0.x"
+    "docs": "0.x",
+    "messages": "1.x"
   },
   "mustUpdateAt": "2019-04-02",
   "scripts": {
@@ -16,7 +17,8 @@
   },
   "dependencies": {
     "vtex.product-context": "0.x",
-    "vtex.css-handles": "1.x"
+    "vtex.css-handles": "1.x",
+    "vtex.native-types": "0.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/messages/context.json
+++ b/messages/context.json
@@ -1,0 +1,14 @@
+{
+  "admin/editor.product-availability.title": "Product Availability",
+  "admin/editor.product-availability.description": "Component that shows the remaining available quantity",
+  "admin/editor.product-availability.threshold.title": "Threshold quantity",
+  "admin/editor.product-availability.threshold.description": "Minimum quantity that makes low stock message appear (if message is set)",
+  "admin/editor.product-availability.lowStockMessage.title": "Low stock message",
+  "admin/editor.product-availability.lowStockMessage.description": "Text to be shown to user when stock is lower than threshold. Should have {quantity} inside the given string, to be replaced for the threshold property. Example: \"Only {quantity} left!\". Leave empty to not show.",
+  "admin/editor.product-availability.highStockMessage.title": "High stock message",
+  "admin/editor.product-availability.highStockMessage.description": "Text to be shown when stock is higher or equal than threshold. If left empty, won't show",
+  "admin/editor.product-availability.showAvailability.title": "Enable availability message",
+  "admin/editor.product-availability.showAvailability.description": "Option to show availability",
+  "admin/editor.product-availability.showAvailabilityMessage.title": "Availability message",
+  "admin/editor.product-availability.showAvailabilityMessage.description": "Text to be shown when \"Enable availability message\" option is set to \"stock\""
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,0 +1,13 @@
+{
+  "admin/editor.product-availability.title": "Product Availability",
+  "admin/editor.product-availability.threshold.title": "Threshold quantity",
+  "admin/editor.product-availability.threshold.description": "Minimum quantity that makes low stock message appear (if message is set)",
+  "admin/editor.product-availability.lowStockMessage.title": "Low stock message",
+  "admin/editor.product-availability.lowStockMessage.description": "Text to be shown to user when stock is lower than threshold. Should have {quantity} inside the given string, to be replaced for the threshold property. Example: \"Only {quantity} left!\". Leave empty to not show.",
+  "admin/editor.product-availability.highStockMessage.title": "High stock message",
+  "admin/editor.product-availability.highStockMessage.description": "Text to be shown when stock is higher or equal than threshold. If left empty, won't show",
+  "admin/editor.product-availability.showAvailability.title": "Enable availability message",
+  "admin/editor.product-availability.showAvailability.description": "Option to show availability",
+  "admin/editor.product-availability.showAvailabilityMessage.title": "Availability message",
+  "admin/editor.product-availability.showAvailabilityMessage.description": "Text to be shown when \"Enable availability message\" option is set to \"stock\""
+}

--- a/react/__test__/__mocks__/vtex.native-types.tsx
+++ b/react/__test__/__mocks__/vtex.native-types.tsx
@@ -1,0 +1,2 @@
+export const formatIOMessage = ({ intl, ...messageDescriptor }: any) =>
+  messageDescriptor.id

--- a/react/components/ProductAvailabilityWrapper.tsx
+++ b/react/components/ProductAvailabilityWrapper.tsx
@@ -3,65 +3,11 @@ import { useProduct } from 'vtex.product-context'
 import type { ProductTypes } from 'vtex.product-context'
 import { useCssHandles } from 'vtex.css-handles'
 import type { CssHandlesTypes } from 'vtex.css-handles'
-import { defineMessages } from 'react-intl'
+import { formatIOMessage } from 'vtex.native-types'
+import { useIntl, defineMessages } from 'react-intl'
 
 import ProductAvailability from './ProductAvailability'
 import { CssHandlesProvider } from './CssHandlesContext'
-
-const messages = defineMessages({
-  title: {
-    defaultMessage: 'Product Availability',
-    id: 'admin/editor.product-availability.title',
-  },
-  description: {
-    defaultMessage: 'Component that shows the remaining available quantity',
-    id: 'admin/editor.product-availability.description',
-  },
-  thresholdTitle: {
-    defaultMessage: 'Threshold quantity',
-    id: 'admin/editor.product-availability.threshold.title',
-  },
-  thresholdDescription: {
-    defaultMessage:
-      'Minimum quantity that makes low stock message appear (if message is set)',
-    id: 'admin/editor.product-availability.threshold.description',
-  },
-  lowStockMessageTitle: {
-    defaultMessage: 'Low stock message',
-    id: 'admin/editor.product-availability.lowStockMessage.title',
-  },
-  lowStockMessageDescription: {
-    defaultMessage:
-      'String to be shown to user when stock is lower than threshold. Should have {quantity} inside the given string, to be replaced for the threshold property. Example: "Only {quantity} left!". Leave empty to not show.',
-    id: 'admin/editor.product-availability.lowStockMessage.description',
-  },
-  highStockMessageTitle: {
-    defaultMessage: 'High stock message',
-    id: 'admin/editor.product-availability.highStockMessage.title',
-  },
-  highStockMessageDescription: {
-    defaultMessage:
-      "String to be shown when stock is higher or equal than threshold. If left empty, won't show",
-    id: 'admin/editor.product-availability.highStockMessage.description',
-  },
-  showAvailabilityTitle: {
-    defaultMessage: 'Enable availability message',
-    id: 'admin/editor.product-availability.showAvailabilityMessage.title',
-  },
-  showAvailabilityDescription: {
-    defaultMessage: 'Option to show availability',
-    id: 'admin/editor.product-availability.showAvailabilityMessage.description',
-  },
-  showAvailabilityMessageTitle: {
-    defaultMessage: 'Availability message',
-    id: 'admin/editor.product-availability.showAvailabilityMessage.title',
-  },
-  showAvailabilityMessageDescription: {
-    defaultMessage:
-      'String to be shown when "Enable availability message" option is set to "stock"',
-    id: 'admin/editor.product-availability.showAvailabilityMessage.description',
-  },
-})
 
 const CONTAINER_CSS_HANDLES = ['container'] as const
 const LOW_STOCK_CSS_HANDLES = ['lowStockText', 'lowStockHighlight'] as const
@@ -94,7 +40,7 @@ interface Props {
   threshold: number
   lowStockMessage?: string
   highStockMessage?: string
-  showAvailability?: 'stock'
+  showAvailability?: 'stock' | 'disabled'
   showAvailabilityMessage?: string
   classes?: CssHandlesTypes.CustomClasses<
     typeof CONTAINER_CSS_HANDLES &
@@ -116,6 +62,22 @@ function ProductAvailabilityWrapper({
 }: Props) {
   const { handles, withModifiers } = useCssHandles(CSS_HANDLES, { classes })
   const productContextValue = useProduct()
+  const intl = useIntl()
+
+  const formattedLowStockMessage = formatIOMessage({
+    id: lowStockMessage,
+    intl,
+  })
+
+  const formattedHighStockMessage = formatIOMessage({
+    id: highStockMessage,
+    intl,
+  })
+
+  const formattedShowAvailabilityMessage = formatIOMessage({
+    id: showAvailabilityMessage,
+    intl,
+  })
 
   if (!productContextValue) {
     return null
@@ -131,50 +93,65 @@ function ProductAvailabilityWrapper({
     <CssHandlesProvider handles={handles} withModifiers={withModifiers}>
       <ProductAvailability
         threshold={threshold}
-        lowStockMessage={lowStockMessage}
-        highStockMessage={highStockMessage}
+        lowStockMessage={formattedLowStockMessage}
+        highStockMessage={formattedHighStockMessage}
         showAvailability={showAvailability}
-        showAvailabilityMessage={showAvailabilityMessage}
+        showAvailabilityMessage={formattedShowAvailabilityMessage}
         availableQuantity={availableQuantity}
       />
     </CssHandlesProvider>
   )
 }
 
-ProductAvailabilityWrapper.schema = {
-  title: messages.title.id,
-  description: messages.description.id,
-  type: 'object',
-  properties: {
-    threshold: {
-      title: messages.thresholdTitle.id,
-      description: messages.thresholdDescription.id,
-      type: 'number',
-      default: 0,
-      isLayout: true,
-    },
-    lowStockMessage: {
-      title: messages.lowStockMessageTitle.id,
-      description: messages.lowStockMessageDescription.id,
-      type: 'string',
-    },
-    highStockMessage: {
-      title: messages.highStockMessageTitle.id,
-      description: messages.highStockMessageDescription.id,
-      type: 'string',
-    },
-    showAvailability: {
-      title: messages.showAvailabilityTitle.id,
-      description: messages.showAvailabilityDescription.id,
-      type: 'enum',
-      enum: ['disabled', 'stock'],
-    },
-    showAvailabilityMessage: {
-      title: messages.showAvailabilityMessageTitle.id,
-      description: messages.showAvailabilityMessageDescription.id,
-      type: 'string',
-    },
+defineMessages({
+  title: {
+    defaultMessage: 'Product Availability',
+    id: 'admin/editor.product-availability.title',
   },
+  lowStockMessageTitle: {
+    defaultMessage: 'Product Availability',
+    id: 'admin/editor.product-availability.lowStockMessage.title',
+  },
+  lowStockMessageDescription: {
+    defaultMessage: 'Product Availability',
+    id: 'admin/editor.product-availability.lowStockMessage.description',
+  },
+  highStockMessageTitle: {
+    defaultMessage: 'Product Availability',
+    id: 'admin/editor.product-availability.highStockMessage.title',
+  },
+  highStockMessageDescription: {
+    defaultMessage: 'Product Availability',
+    id: 'admin/editor.product-availability.highStockMessage.description',
+  },
+  showAvailabilityMessageTitle: {
+    defaultMessage: 'Product Availability',
+    id: 'admin/editor.product-availability.showAvailabilityMessage.title',
+  },
+  showAvailabilityMessageDescription: {
+    defaultMessage: 'Product Availability',
+    id: 'admin/editor.product-availability.showAvailabilityMessage.description',
+  },
+  thresholdTitle: {
+    defaultMessage: 'Product Availability',
+    id: 'admin/editor.product-availability.threshold.title',
+  },
+  thresholdDescription: {
+    defaultMessage: 'Product Availability',
+    id: 'admin/editor.product-availability.threshold.description',
+  },
+  showAvailabilityTitle: {
+    defaultMessage: 'Product Availability',
+    id: 'admin/editor.product-availability.showAvailability.title',
+  },
+  showAvailabilityDescription: {
+    defaultMessage: 'Product Availability',
+    id: 'admin/editor.product-availability.showAvailability.description',
+  },
+})
+
+ProductAvailabilityWrapper.schema = {
+  title: 'admin/editor.product-availability.title',
 }
 
 export default ProductAvailabilityWrapper

--- a/react/components/ProductAvailabilityWrapper.tsx
+++ b/react/components/ProductAvailabilityWrapper.tsx
@@ -67,17 +67,17 @@ function ProductAvailabilityWrapper({
   const formattedLowStockMessage = formatIOMessage({
     id: lowStockMessage,
     intl,
-  })
+  }) as string
 
   const formattedHighStockMessage = formatIOMessage({
     id: highStockMessage,
     intl,
-  })
+  }) as string
 
   const formattedShowAvailabilityMessage = formatIOMessage({
     id: showAvailabilityMessage,
     intl,
-  })
+  }) as string
 
   if (!productContextValue) {
     return null

--- a/react/components/ProductAvailabilityWrapper.tsx
+++ b/react/components/ProductAvailabilityWrapper.tsx
@@ -109,43 +109,47 @@ defineMessages({
     id: 'admin/editor.product-availability.title',
   },
   lowStockMessageTitle: {
-    defaultMessage: 'Product Availability',
+    defaultMessage: 'Low stock message',
     id: 'admin/editor.product-availability.lowStockMessage.title',
   },
   lowStockMessageDescription: {
-    defaultMessage: 'Product Availability',
+    defaultMessage:
+      'Text to be shown to user when stock is lower than threshold. Should have {quantity} inside the given string, to be replaced for the threshold property. Example: "Only {quantity} left!". Leave empty to not show.',
     id: 'admin/editor.product-availability.lowStockMessage.description',
   },
   highStockMessageTitle: {
-    defaultMessage: 'Product Availability',
+    defaultMessage: 'High stock message',
     id: 'admin/editor.product-availability.highStockMessage.title',
   },
   highStockMessageDescription: {
-    defaultMessage: 'Product Availability',
+    defaultMessage:
+      "Text to be shown when stock is higher or equal than threshold. If left empty, won't show",
     id: 'admin/editor.product-availability.highStockMessage.description',
   },
   showAvailabilityMessageTitle: {
-    defaultMessage: 'Product Availability',
+    defaultMessage: 'Availability message',
     id: 'admin/editor.product-availability.showAvailabilityMessage.title',
   },
   showAvailabilityMessageDescription: {
-    defaultMessage: 'Product Availability',
+    defaultMessage:
+      'Text to be shown when "Enable availability message" option is set to "stock"',
     id: 'admin/editor.product-availability.showAvailabilityMessage.description',
   },
   thresholdTitle: {
-    defaultMessage: 'Product Availability',
+    defaultMessage: 'Threshold quantity',
     id: 'admin/editor.product-availability.threshold.title',
   },
   thresholdDescription: {
-    defaultMessage: 'Product Availability',
+    defaultMessage:
+      'Minimum quantity that makes low stock message appear (if message is set)',
     id: 'admin/editor.product-availability.threshold.description',
   },
   showAvailabilityTitle: {
-    defaultMessage: 'Product Availability',
+    defaultMessage: 'Enable availability message',
     id: 'admin/editor.product-availability.showAvailability.title',
   },
   showAvailabilityDescription: {
-    defaultMessage: 'Product Availability',
+    defaultMessage: 'Option to show availability',
     id: 'admin/editor.product-availability.showAvailability.description',
   },
 })

--- a/react/components/ProductAvailabilityWrapper.tsx
+++ b/react/components/ProductAvailabilityWrapper.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import { useProduct } from 'vtex.product-context'
 import type { ProductTypes } from 'vtex.product-context'
 import { useCssHandles } from 'vtex.css-handles'
@@ -64,20 +64,32 @@ function ProductAvailabilityWrapper({
   const productContextValue = useProduct()
   const intl = useIntl()
 
-  const formattedLowStockMessage = formatIOMessage({
-    id: lowStockMessage,
-    intl,
-  }) as string
+  const formattedLowStockMessage = useMemo(
+    () =>
+      formatIOMessage({
+        id: lowStockMessage,
+        intl,
+      }),
+    [lowStockMessage, intl]
+  ) as string
 
-  const formattedHighStockMessage = formatIOMessage({
-    id: highStockMessage,
-    intl,
-  }) as string
+  const formattedHighStockMessage = useMemo(
+    () =>
+      formatIOMessage({
+        id: highStockMessage,
+        intl,
+      }),
+    [highStockMessage, intl]
+  ) as string
 
-  const formattedShowAvailabilityMessage = formatIOMessage({
-    id: showAvailabilityMessage,
-    intl,
-  }) as string
+  const formattedShowAvailabilityMessage = useMemo(
+    () =>
+      formatIOMessage({
+        id: showAvailabilityMessage,
+        intl,
+      }),
+    [showAvailabilityMessage, intl]
+  ) as string
 
   if (!productContextValue) {
     return null

--- a/react/package.json
+++ b/react/package.json
@@ -12,7 +12,6 @@
     "@vtex/test-tools": "^3.1.0",
     "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@1.0.0/public/@types/vtex.css-handles",
     "vtex.native-types": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.5/public/@types/vtex.native-types",
-    "vtex.product-availability": "https://victormiranda--storecomponents.myvtex.com/_v/private/typings/linked/v1/vtex.product-availability@0.2.0+build1645631307/public/@types/vtex.product-availability",
     "vtex.product-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.10.0/public/@types/vtex.product-context",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.3/public/@types/vtex.render-runtime"
   },

--- a/react/package.json
+++ b/react/package.json
@@ -11,8 +11,10 @@
     "@apollo/react-testing": "^3.1.4",
     "@vtex/test-tools": "^3.1.0",
     "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@1.0.0/public/@types/vtex.css-handles",
-    "vtex.product-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.9.7/public/@types/vtex.product-context",
-    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.11/public/@types/vtex.render-runtime"
+    "vtex.native-types": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.5/public/@types/vtex.native-types",
+    "vtex.product-availability": "https://victormiranda--storecomponents.myvtex.com/_v/private/typings/linked/v1/vtex.product-availability@0.2.0+build1645631307/public/@types/vtex.product-availability",
+    "vtex.product-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.10.0/public/@types/vtex.product-context",
+    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.3/public/@types/vtex.render-runtime"
   },
   "version": "0.2.0"
 }

--- a/react/typings/vtex.native.types.d.ts
+++ b/react/typings/vtex.native.types.d.ts
@@ -1,0 +1,1 @@
+declare module 'vtex.native-types'

--- a/react/typings/vtex.native.types.d.ts
+++ b/react/typings/vtex.native.types.d.ts
@@ -1,1 +1,0 @@
-declare module 'vtex.native-types'

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4951,10 +4951,6 @@ verror@1.10.0:
   version "0.7.5"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.5/public/@types/vtex.native-types#52d8c0b675fcdf2b6b1ca93f6a99a630519f618f"
 
-"vtex.product-availability@https://victormiranda--storecomponents.myvtex.com/_v/private/typings/linked/v1/vtex.product-availability@0.2.0+build1645631307/public/@types/vtex.product-availability":
-  version "0.2.1-beta.1"
-  resolved "https://victormiranda--storecomponents.myvtex.com/_v/private/typings/linked/v1/vtex.product-availability@0.2.0+build1645631307/public/@types/vtex.product-availability#ce13d4896e5274e3813f2ee53b110a693eb1c1b5"
-
 "vtex.product-context@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.10.0/public/@types/vtex.product-context":
   version "0.10.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.10.0/public/@types/vtex.product-context#c5e2a97b404004681ee12f4fff7e6b62157786cc"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4947,13 +4947,21 @@ verror@1.10.0:
   version "1.0.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@1.0.0/public/@types/vtex.css-handles#336b23ef3a9bcb2b809529ba736783acd405d081"
 
-"vtex.product-context@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.9.7/public/@types/vtex.product-context":
-  version "0.9.7"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.9.7/public/@types/vtex.product-context#4024c589f1ba318e92219a88bf18b4e3774dc85c"
+"vtex.native-types@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.5/public/@types/vtex.native-types":
+  version "0.7.5"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.5/public/@types/vtex.native-types#52d8c0b675fcdf2b6b1ca93f6a99a630519f618f"
 
-"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.11/public/@types/vtex.render-runtime":
-  version "8.126.11"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.11/public/@types/vtex.render-runtime#aceb734766093b56954ec19a074574b4c2c95242"
+"vtex.product-availability@https://victormiranda--storecomponents.myvtex.com/_v/private/typings/linked/v1/vtex.product-availability@0.2.0+build1645631307/public/@types/vtex.product-availability":
+  version "0.2.1-beta.1"
+  resolved "https://victormiranda--storecomponents.myvtex.com/_v/private/typings/linked/v1/vtex.product-availability@0.2.0+build1645631307/public/@types/vtex.product-availability#ce13d4896e5274e3813f2ee53b110a693eb1c1b5"
+
+"vtex.product-context@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.10.0/public/@types/vtex.product-context":
+  version "0.10.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.10.0/public/@types/vtex.product-context#c5e2a97b404004681ee12f4fff7e6b62157786cc"
+
+"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.3/public/@types/vtex.render-runtime":
+  version "8.132.3"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.3/public/@types/vtex.render-runtime#c7dd142e384f38bd7a7c841543b73e9349fadc93"
 
 w3c-hr-time@^1.0.1:
   version "1.0.2"

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -1,0 +1,38 @@
+{
+  "definitions": {
+    "ProductAvailability": {
+      "properties": {
+        "lowStockMessage": {
+          "title": "admin/editor.product-availability.lowStockMessage.title",
+          "description": "admin/editor.product-availability.lowStockMessage.description",
+          "default": "",
+          "$ref": "app:vtex.native-types#/definitions/text"
+        },
+        "highStockMessage": {
+          "title": "admin/editor.product-availability.highStockMessage.title",
+          "description": "admin/editor.product-availability.highStockMessage.description",
+          "default": "",
+          "$ref": "app:vtex.native-types#/definitions/text"
+        },
+        "showAvailabilityMessage": {
+          "title": "admin/editor.product-availability.showAvailabilityMessage.title",
+          "description": "admin/editor.product-availability.showAvailabilityMessage.description",
+          "default": "",
+          "$ref": "app:vtex.native-types#/definitions/text"
+        },
+        "threshold": {
+          "title": "admin/editor.product-availability.threshold.title",
+          "description": "admin/editor.product-availability.threshold.description",
+          "type": "number",
+          "default": 0
+        },
+        "showAvailability": {
+          "title": "admin/editor.product-availability.showAvailability.title",
+          "description": "admin/editor.product-availability.showAvailability.description",
+          "default": "disabled",
+          "enum": ["disabled", "stock"]
+        }
+      }
+    }
+  }
+}

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -1,5 +1,8 @@
 {
   "product-availability": {
-    "component": "ProductAvailability"
+    "component": "ProductAvailability",
+    "content": {
+      "$ref": "app:vtex.product-availability#/definitions/ProductAvailability"
+    }
   }
 }


### PR DESCRIPTION
#### What problem is this solving?

The `product-availability` block did not support proper Site Editor configuration. And it also didn't support different prop values for different locales. This PR adds both :).

#### How to test it?

Go to [Workspace](https://victormiranda--storecomponents.myvtex.com/admin/cms/site-editor) to edit this block in the Site Editor.

Go a PDP, such as [this one](https://victormiranda--storecomponents.myvtex.com/working-shirt/p), and notice that when you change the locale (using the locale-switcher) to PT, EN or JA you get a different text shown by the `product-availability` block.

#### Screenshots or example usage:

![Screen Shot 2022-02-23 at 17 31 45](https://user-images.githubusercontent.com/27777263/155403339-74ba6ef0-1fa4-4fdb-9dd9-b8731c938e2d.png)