### PR TITLE
Show the component even if the stock is 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.3.2] - 2022-11-09
+### Added
+- Render the component even when the stock is 0.
+
 ## [0.3.1] - 2022-02-25
 
 ## [0.3.0] - 2022-02-24

--- a/react/components/ProductAvailability.tsx
+++ b/react/components/ProductAvailability.tsx
@@ -23,7 +23,7 @@ function ProductAvailability({
   showAvailabilityMessage,
   availableQuantity,
 }: Props) {
-  if (!availableQuantity || availableQuantity < 0) {
+  if (availableQuantity == null || availableQuantity < 0) {
     return null
   }
 

--- a/react/components/ProductAvailability.tsx
+++ b/react/components/ProductAvailability.tsx
@@ -23,7 +23,7 @@ function ProductAvailability({
   showAvailabilityMessage,
   availableQuantity,
 }: Props) {
-  if (!availableQuantity || availableQuantity < 1) {
+  if (!availableQuantity || availableQuantity < 0) {
     return null
   }
 


### PR DESCRIPTION
Make this component usable even if the product is out of stock; even the default value is 0. I didn't remove the condition, but replaced 1 with 0 to prevent any issues if bugs occur on the way.

#### What problem is this solving?

Make this component usable for products out of stock. 

#### How to test it?

N/A

#### Screenshots or example usage:

N/A

#### Describe alternatives you've considered, if any.

N/A

#### Related to / Depends on

N/A

#### How does this PR make you feel? [:link:](http://giphy.com/)

N/A
